### PR TITLE
Fix Logic behind Version Check

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,10 +39,10 @@ module.exports = {
                 options.proxy.log({
                     name: options.name,
                     source: 'plugin',
-                    type: result.latest ? 'success' : 'info',
-                    message: result.latest
+                    type: result.newest ? 'success' : 'info',
+                    message: result.newest
                         ? `You have the latest version v${result.current}.`
-                        : `Your current version is v${result.current} and the latest version is v${result.newest}. Click <a href="${result.download_link}">here</a> to download the latest version.`
+                        : `Your current version is v${result.current} and the latest version is v${result.latest}. Click <a href="${result.download_link}">here</a> to download the latest version.`
                 });
             })
             .catch(error => {


### PR DESCRIPTION
Fixed logic behind checking a repo version.
**Before:** If request successfuly retrieved latest version tag, then no matter of installed version people in SWEX would get **You have the latest version v[xxx]**. Variable **newest** wasn't used anywhere.
**After:** Variable **newest** (as expected) checks if current & latest versions are the same. If they are, SWEX prints **You have the latest version v[xxx]**. If no, then prints **Your current version is v[xxx] and the latest version is v[yyy] Click _here_ to download the latest version.**. Link works as intended.